### PR TITLE
fix: DWP-257: Jira ticket fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,6 @@ module.exports = app => {
 
     const branch = ref.replace(/^refs\/heads\//, '')
 
-    console.log('branch :', branch)
-    console.log('config.branches : ', config.branches)
-
     if (!isTriggerableBranch({ branch, app, context, config })) {
       return
     }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ module.exports = app => {
 
     const branch = ref.replace(/^refs\/heads\//, '')
 
+    console.log('branch :', branch)
+    console.log('config.branches : ', config.branches)
+
     if (!isTriggerableBranch({ branch, app, context, config })) {
       return
     }

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -25,6 +25,7 @@ const types = [
 ]
 
 const regex = new RegExp(types.join('|'), 'gi')
+const URL_REGEX = new RegExp('https://.+browse.+(d+)(|[^a-zA-Z][0-9-])', 'gi')
 
 const sortReleases = releases => {
   // For semver, we find the greatest release number
@@ -165,7 +166,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
         let url
         let tester
         if (description) {
-          url = description.match(/(https?:\/\/)?([^.\s]+)?[^.\s]+\.[^\s]+/gi)
+          url = description.match(URL_REGEX)
           tester = description.match(/@(\w+)\W/g)
         }
         let body = ''

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -25,7 +25,10 @@ const types = [
 ]
 
 const regex = new RegExp(types.join('|'), 'gi')
-const URL_REGEX = new RegExp('https://.+browse.+(d+)(|[^a-zA-Z][0-9-])', 'gi')
+const URL_REGEX = new RegExp(
+  'https:\\/\\/.+browse.+(\\d+)(|[^a-zA-Z][0-9-])',
+  'gi'
+)
 
 const sortReleases = releases => {
   // For semver, we find the greatest release number

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -166,15 +166,15 @@ const generateChangeLog = (mergedPullRequests, config) => {
     pullRequests
       .map(pullRequest => {
         const description = pullRequest.body
-        let url
+        let urls
         let tester
         if (description) {
-          url = description.match(URL_REGEX)
+          urls = description.match(URL_REGEX)
           tester = description.match(/@(\w+)\W/g)
         }
         let body = ''
         if (tester) body = tester[0]
-        if (url) body = body + '\n' + url[0]
+        if (urls) body = body + '\n' + urls.map(url => ' - ' + url).join('\n')
         return template(config['change-template'], {
           $TITLE: pullRequest.title,
           $NUMBER: pullRequest.number,

--- a/test/fixtures/__generated__/graphql-commits-merge-commit-with-title.json
+++ b/test/fixtures/__generated__/graphql-commits-merge-commit-with-title.json
@@ -23,6 +23,7 @@
                   "nodes": [
                     {
                       "title": "feature: Add documentation @tester https://abc.atlassian.net/browse/DWP-37",
+                      "body": "[Ticket 1 description](https://abc.atlassian.net/browse/DWP-123)\n[Ticket 2 Description](https://abc.atlassian.net/browse/DWP-456)",
                       "number": 5,
                       "author": {
                         "login": "TimonVS"

--- a/test/fixtures/config/config-with-categories-description.yml
+++ b/test/fixtures/config/config-with-categories-description.yml
@@ -1,0 +1,18 @@
+template: |
+  # What's Changed
+
+  $CHANGES
+
+categories:
+  - title: 🚀 Features
+    labels:
+      - feature
+      - enhancement
+  - title: 🐛 Bug Fixes
+    labels:
+      - fix
+      - bugfix
+      - bug
+  - title: 👻 Maintenance
+    label: chore
+change-template: '* $TITLE (#$NUMBER) @$AUTHOR$DESC'


### PR DESCRIPTION
Fixes issues in https://dream11.atlassian.net/browse/DWP-257

- JIRA link appears in the next line without showing a bullet point - Added bullet point
- One of the JIRA links was prepended with a “CMT]“.  - Fixed Regular expression
- On PRs that do not have a JIRA ticket (e.g., update satan), the drafter simple takes the next Atlassian link available in the PR description (https://dream11.atlassian.net/secure/RapidBoard.jspa?rapidView=17) - Fixed regular expression
- One of the PRs was mentioned twice - once in chores and once in fixes. - This is expected behaviour. If a PR has two labels it will be part of 2 categories. 